### PR TITLE
Update .Net version

### DIFF
--- a/coding-dojo-csharp.csproj
+++ b/coding-dojo-csharp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>coding_dojo_csharp</RootNamespace>
 
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
NetCore 3.1 out of support December 13, 2022
In 2025, the current and supported versions are .Net 8 and .Net 9.
[https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core)

So I updated the .NET version and made sure that everything works (the project compiles and the tests run).